### PR TITLE
Remove unneccessary Numba usage -> use numpy vectorization

### DIFF
--- a/.github/workflows/test_conda.yml
+++ b/.github/workflows/test_conda.yml
@@ -17,17 +17,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.12
+    - name: Set up Python 3.14
       uses: actions/setup-python@v2
       with:
-        python-version: 3.12
+        python-version: 3.14
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda install -c conda-forge libsndfile python=3.11
+        conda install -c conda-forge libsndfile python=3.14
         python -m pip install .['test']
     - name: Lint with flake8
       run: |

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -23,6 +23,8 @@ jobs:
           - '3.10'
           - 3.11
           - 3.12
+          - 3.13
+          - 3.14
 
     steps:
     - uses: actions/checkout@v2

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,9 @@ channels:
   - conda-forge
 
 dependencies:
-  - python>=3.8.0, <3.13.0
+  - python>=3.10.0, <3.15.0
   - ipython
   - jupyter
 
   - pip:
-    - synctoolbox==1.2.*
+    - synctoolbox==1.4.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "synctoolbox"
 version = "1.4.1"
 description = "Python Package for Efficient, Robust, and Accurate Music Synchronization (Sync Toolbox)"
 readme = "README.md"
-requires-python = ">=3.10, <3.13.0"
+requires-python = ">=3.10, <3.15.0"
 license = {text = "MIT"}
 authors = [
     {name = "Meinard Müller", email = "meinard.mueller@audiolabs-erlangen.de"},
@@ -24,16 +24,16 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "librosa >= 0.10.0, < 1.0.0",
-    "matplotlib >= 3.1.0, < 4.0.0",
-    "music21 >= 9.1.0, < 10.0.0",
-    "numba >= 0.58.1, < 0.60.0",
-    "numpy >= 1.17.0, < 2.0.0",
-    "pandas >= 2.1.0, < 3.0.0",
-    "pretty_midi >= 0.2.0, < 1.0.0",
-    "soundfile >= 0.9.0, < 1.0.0",
-    "scipy >= 1.7.0, < 2.0.0",
-    "libfmp >= 1.2.0, < 2.0.0"
+    "librosa >= 0.11.0, < 1.0.0",
+    "matplotlib >= 3.10.0, < 4.0.0",
+    "music21 >= 9.9.0, < 10.0.0",
+    "numba >= 0.63.0, < 0.66.0",
+    "numpy >= 2.0.0, < 2.5.0",
+    "pandas >= 2.3.0, < 3.0.0",
+    "pretty_midi >= 0.2.11, < 1.0.0",
+    "soundfile >= 0.13.0, < 1.0.0",
+    "scipy >= 1.15.0, < 2.0.0",
+    "libfmp >= 1.3.0, < 2.0.0"
 ]
 
 [project.optional-dependencies]
@@ -43,7 +43,7 @@ develop = [
     "jupyter",
     "nbstripout"
 ]
-test = ["pytest == 6.2.*"]
+test = ["pytest >= 8.3.0, < 9.0.0"]
 doc = [
     "sphinx == 4.0.*",
     "sphinx_rtd_theme == 0.5.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "synctoolbox"
-version = "1.4.1"
+version = "1.4.2"
 description = "Python Package for Efficient, Robust, and Accurate Music Synchronization (Sync Toolbox)"
 readme = "README.md"
 requires-python = ">=3.10, <3.15.0"

--- a/sync_audio_audio_simple.ipynb
+++ b/sync_audio_audio_simple.ipynb
@@ -90,7 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "audio_2, _ = librosa.load('data_music/Schubert_D911-01_SC06.wav', Fs)\n",
+    "audio_2, _ = librosa.load('data_music/Schubert_D911-01_SC06.wav', sr=Fs)\n",
     "\n",
     "plot_signal(audio_2, Fs=Fs, ylabel='Amplitude', title='Version 2', figsize=figsize)\n",
     "ipd.display(ipd.Audio(audio_2, rate=Fs))"
@@ -228,7 +228,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -242,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/synctoolbox/dtw/anchor.py
+++ b/synctoolbox/dtw/anchor.py
@@ -1,4 +1,3 @@
-from numba import jit
 import numpy as np
 from typing import Tuple
 
@@ -137,11 +136,9 @@ def derive_neighboring_anchors(warping_path: np.ndarray,
     return neighboring_anchors, neighboring_anchor_indices
 
 
-@jit(nopython=True)
 def __compute_area(a: tuple,
                    b: tuple):
     """Computes the area between two points, given as tuples"""
     return (b[0] - a[0] + 1) * (b[1] - a[1] + 1)
-
 
 

--- a/synctoolbox/dtw/cost.py
+++ b/synctoolbox/dtw/cost.py
@@ -1,9 +1,7 @@
-from numba import jit
 import numpy as np
 from sklearn.metrics.pairwise import euclidean_distances
 
 
-#@jit(nopython=True)
 def cosine_distance(f1, f2, cos_meas_max=2.0, cos_meas_min=1.0):
     """For all pairs of vectors f1' and f2' in f1 and f2, computes 1 - (f1.f2),
     where '.' is the dot product, and rescales the results to lie in the
@@ -13,8 +11,6 @@ def cosine_distance(f1, f2, cos_meas_max=2.0, cos_meas_min=1.0):
     return (1 - f1.T @ f2) * (cos_meas_max - cos_meas_min) + cos_meas_min
 
 
-
-#@jit(nopython=True)
 def euclidean_distance(f1, f2, l2_meas_max=1.0, l2_meas_min=0.0):
     """Computes euclidean distances between the vectors in f1 and f2, and
     rescales the results to lie in the range [cos_meas_min, cos_meas_max]."""
@@ -76,4 +72,3 @@ def compute_high_res_cost_matrix(f_chroma1: np.ndarray,
     euc_dis = euclidean_distance(f_onset1, f_onset2, l2_meas_min=l2_meas_min, l2_meas_max=l2_meas_max)
 
     return weights[0] * cos_dis + weights[1] * euc_dis
-

--- a/synctoolbox/dtw/mrmsdtw.py
+++ b/synctoolbox/dtw/mrmsdtw.py
@@ -1,4 +1,3 @@
-from numba import jit
 import numpy as np
 import time
 from typing import List, Tuple, Optional
@@ -495,7 +494,6 @@ def __diagonal_warping_path(f1: np.ndarray,
         return np.array([np.linspace(0, min_size-1, min_size), np.round(np.linspace(0, max_size - 1, min_size))])
 
 
-@jit(nopython=True)
 def __compute_area(f1, f2):
     """Computes the area of the cost matrix given two feature sequences
 

--- a/synctoolbox/dtw/utils.py
+++ b/synctoolbox/dtw/utils.py
@@ -228,11 +228,12 @@ def find_anchor_indices_in_warping_path(warping_path: np.ndarray,
     indices : np.ndarray [shape=(2, M)]
         Anchor indices in the ``warping_path``
     """
-    indices = np.zeros(anchors.shape[1])
+    indices = np.zeros(anchors.shape[1], dtype=int)
 
     for k in range(anchors.shape[1]):
         a = anchors[:, k]
-        indices[k] = np.where((a[0] == warping_path[0, :]) & (a[1] == warping_path[1, :]))[0]
+        anchor_indices = np.flatnonzero((a[0] == warping_path[0, :]) & (a[1] == warping_path[1, :]))
+        indices[k] = anchor_indices[0]
 
     return indices
 

--- a/synctoolbox/feature/dlnco.py
+++ b/synctoolbox/feature/dlnco.py
@@ -71,8 +71,8 @@ def pitch_onset_features_to_DLNCO(f_peaks: dict,
     for midi_pitch in range(midi_min, midi_max + 1):
         if midi_pitch not in f_peaks:
             continue
-        time_peaks = f_peaks[midi_pitch][0, :] / 1000  # Now given in seconds
-        val_peaks = np.log(f_peaks[midi_pitch][1, :] * log_compression_gamma + 1)
+        time_peaks = np.asarray(f_peaks[midi_pitch][0, :] / 1000).reshape(-1)  # Now given in seconds
+        val_peaks = np.asarray(np.log(f_peaks[midi_pitch][1, :] * log_compression_gamma + 1)).reshape(-1)
         ind_chroma = np.mod(midi_pitch, 12)
         for k in range(time_peaks.size):
             indTime = __matlab_round(time_peaks[k] * feature_rate)  # Usage of "round" accounts
@@ -166,6 +166,7 @@ def __visualize_LN_features(f_N: np.ndarray,
 
 def __matlab_round(x: float = None) -> int:
     """Workaround to cope the rounding differences between MATLAB and python"""
+    x = float(np.asarray(x).squeeze())
     if x - np.floor(x) < 0.5:
         return int(np.floor(x))
     else:

--- a/synctoolbox/feature/pitch.py
+++ b/synctoolbox/feature/pitch.py
@@ -1,6 +1,5 @@
 from libfmp.b import plot_matrix
 import numpy as np
-from numba import jit
 import matplotlib.pyplot as plt
 from scipy import signal
 
@@ -118,10 +117,9 @@ def audio_to_pitch_features(f_audio: np.ndarray,
     return f_pitch
 
 
-@jit(nopython=True)
 def __window_and_sum(f_pitch, f_square, midi_pitch, seg_wav_num, start, stop, factor):
-    for k in range(seg_wav_num):  # TODO this is extremely inefficient, can we use better numpy indexing to improve this? np.convolve?
-        f_pitch[midi_pitch, k] = np.sum(f_square[start[k]:stop[k]]) * factor
+    prefix_sum = np.concatenate([np.zeros(1, dtype=f_square.dtype), np.cumsum(f_square)])
+    f_pitch[midi_pitch, :seg_wav_num] = (prefix_sum[stop] - prefix_sum[start]) * factor
 
 
 def __visualize_pitch(f_pitch: np.ndarray,
@@ -151,4 +149,3 @@ def __visualize_pitch(f_pitch: np.ndarray,
     else:
         ax[0].set_yticks(pitchscale[::2])
         ax[0].set_yticklabels(pitchscale[::2], fontsize=10)
-

--- a/synctoolbox/feature/pitch_onset.py
+++ b/synctoolbox/feature/pitch_onset.py
@@ -195,8 +195,7 @@ def __f_peaks_to_matrix(max_length_sec, f_peaks, highest_time_res, midi_max, mid
             continue
 
         for k in range(f_peaks[midi_pitch].shape[1]):
-            timecoord = np.minimum(__ms2imagecoord(f_peaks[midi_pitch][0, k], highest_time_res), time_grid_width) \
-                .astype(int)
+            timecoord = int(np.minimum(__ms2imagecoord(f_peaks[midi_pitch][0, k], highest_time_res), time_grid_width))
             imagedata[np.maximum(1, np.arange(timecoord - 3, timecoord + 4)), midi_pitch - midi_min] = \
                 f_peaks[midi_pitch][1, k]
     return imagedata
@@ -205,6 +204,7 @@ def __f_peaks_to_matrix(max_length_sec, f_peaks, highest_time_res, midi_max, mid
 def __ms2imagecoord(timems: float,
                     highest_time_res: float) -> float:
     """Round ``timems`` onto a discrete grid defined by 'highest_time_res'"""
+    timems = float(np.asarray(timems).squeeze())
     coord = np.round(timems / (highest_time_res * 1000))
     return coord
 

--- a/synctoolbox/feature/utils.py
+++ b/synctoolbox/feature/utils.py
@@ -1,5 +1,4 @@
 from libfmp.c3 import compute_freq_distribution, tuning_similarity
-from numba import jit
 import numpy as np
 from scipy import signal
 from typing import Tuple
@@ -52,7 +51,6 @@ def smooth_downsample_feature(f_feature: np.ndarray,
     return f_feature_stat, new_feature_rate
 
 
-@jit(nopython=True)
 def normalize_feature(feature: np.ndarray,
                       norm_ord: int,
                       threshold: float) -> np.ndarray:
@@ -77,21 +75,17 @@ def normalize_feature(feature: np.ndarray,
     f_normalized : np.ndarray
         Normalized feature sequence
     """
-    # TODO rewrite in vectorized fashion
     d, N = feature.shape
-    f_normalized = np.zeros((d, N))
 
     # normalize the vectors according to the l^norm_ord norm
     unit_vec = np.ones(d)
     unit_vec = unit_vec / np.linalg.norm(unit_vec, norm_ord)
 
-    for k in range(N):
-        cur_norm = np.linalg.norm(feature[:, k], norm_ord)
-
-        if cur_norm < threshold:
-            f_normalized[:, k] = unit_vec
-        else:
-            f_normalized[:, k] = feature[:, k] / cur_norm
+    norms = np.linalg.norm(feature, ord=norm_ord, axis=0)
+    below_threshold = norms < threshold
+    safe_norms = np.where(below_threshold, 1.0, norms)
+    f_normalized = feature / safe_norms.reshape(1, N)
+    f_normalized[:, below_threshold] = unit_vec.reshape(d, 1)
 
     return f_normalized
 


### PR DESCRIPTION
## Note
Contains changes from PR #38 , so it should be merged first.

## Summary
Remove unnecessary Numba usage from helpers that are either already vectorized, trivially small, or safely replaceable with NumPy.

## File-by-file Changes

### `synctoolbox/feature/utils.py`
- Replaced the column-by-column normalization loop with vectorized NumPy logic:
  - computes all column norms at once with `np.linalg.norm(..., axis=0)`
  - identifies below-threshold columns with a boolean mask
  - normalizes regular columns in one array operation
  - replaces below-threshold columns with the normalized all-ones unit vector

### `synctoolbox/feature/pitch.py`
- Replaced repeated slice summation in a loop with a cumulative-sum implementation:
  - builds a prefix sum of `f_square`
  - computes each variable-length window sum as `prefix_sum[stop] - prefix_sum[start]`
  - writes all segment sums into `f_pitch[midi_pitch, :]` at once

### `synctoolbox/dtw/anchor.py`
- Removed jit decorator, function is trivially small

### `synctoolbox/dtw/mrmsdtw.py`
- Removed jit decorator, function is trivially small

### `synctoolbox/dtw/cost.py`
- Removed unused `from numba import jit`.
- Removed stale commented-out `#@jit(nopython=True)` lines above `cosine_distance` and `euclidean_distance`.

## Verification & Testing
- Full test suite passes
- Performed a custom regression test by comparing before/after function outputs with tight tolerance