### PR TITLE
fix for numpy 2.4.4

### DIFF
--- a/sync_audio_audio_simple.ipynb
+++ b/sync_audio_audio_simple.ipynb
@@ -67,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "audio_1, _ = librosa.load('data_music/Schubert_D911-01_HU33.wav', sr=Fs)\n",
+    "audio_1, _ = librosa.load('data_music/Schubert_D911-01_HU33.wav')\n",
     "\n",
     "plot_signal(audio_1, Fs=Fs, ylabel='Amplitude', title='Version 1', figsize=figsize)\n",
     "ipd.display(ipd.Audio(audio_1, rate=Fs))"
@@ -90,7 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "audio_2, _ = librosa.load('data_music/Schubert_D911-01_SC06.wav', Fs)\n",
+    "audio_2, _ = librosa.load('data_music/Schubert_D911-01_SC06.wav')\n",
     "\n",
     "plot_signal(audio_2, Fs=Fs, ylabel='Amplitude', title='Version 2', figsize=figsize)\n",
     "ipd.display(ipd.Audio(audio_2, rate=Fs))"

--- a/synctoolbox/dtw/utils.py
+++ b/synctoolbox/dtw/utils.py
@@ -228,11 +228,14 @@ def find_anchor_indices_in_warping_path(warping_path: np.ndarray,
     indices : np.ndarray [shape=(2, M)]
         Anchor indices in the ``warping_path``
     """
-    indices = np.zeros(anchors.shape[1])
+    indices = np.zeros(anchors.shape[1], dtype=np.int64)
 
     for k in range(anchors.shape[1]):
         a = anchors[:, k]
-        indices[k] = np.where((a[0] == warping_path[0, :]) & (a[1] == warping_path[1, :]))[0]
+        matches = np.where((a[0] == warping_path[0, :]) & (a[1] == warping_path[1, :]))[0]
+        if matches.size == 0:
+            raise ValueError(f"Anchor {a.tolist()} not found in warping path")
+        indices[k] = matches[0]
 
     return indices
 

--- a/synctoolbox/dtw/utils.py
+++ b/synctoolbox/dtw/utils.py
@@ -225,7 +225,7 @@ def find_anchor_indices_in_warping_path(warping_path: np.ndarray,
 
     Returns
     -------
-    indices : np.ndarray [shape=(2, M)]
+    indices : np.ndarray [shape=(M,)]
         Anchor indices in the ``warping_path``
     """
     indices = np.zeros(anchors.shape[1], dtype=np.int64)

--- a/synctoolbox/dtw/utils.py
+++ b/synctoolbox/dtw/utils.py
@@ -232,7 +232,10 @@ def find_anchor_indices_in_warping_path(warping_path: np.ndarray,
 
     for k in range(anchors.shape[1]):
         a = anchors[:, k]
-        matches = np.where((a[0] == warping_path[0, :]) & (a[1] == warping_path[1, :]))[0]
+        matches = np.flatnonzero(
+            np.isclose(a[0], warping_path[0, :]) &
+            np.isclose(a[1], warping_path[1, :])
+        )
         if matches.size == 0:
             raise ValueError(f"Anchor {a.tolist()} not found in warping path")
         indices[k] = matches[0]


### PR DESCRIPTION
i am trying to use `synctoolbox` with unpinned dependencies

my `sync.py` is based on `sync_audio_audio_simple.ipynb`

error was

```
TypeError: only 0-dimensional arrays can be converted to Python scalars

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "sync.py", line 79, in <module>
    alignment = sync_via_mrmsdtw(
        f_chroma1=chroma_1,
    ...<2 lines>...
        verbose=True
    )
File "/nix/store/nd1slff02whgrh350dzb4lgrmw0hwqfq-synctoolbox-1.4.1/lib/python3.13/site-packages/synctoolbox/dtw/mrmsdtw.py", line 413, in sync_via_mrmsdtw
    anchor_indices_in_warping_path = find_anchor_indices_in_warping_path(wp, anchors=anchors)
File "/nix/store/nd1slff02whgrh350dzb4lgrmw0hwqfq-synctoolbox-1.4.1/lib/python3.13/site-packages/synctoolbox/dtw/utils.py", line 235, in find_anchor_indices_in_warping_path
    indices[k] = np.where((a[0] == warping_path[0, :]) & (a[1] == warping_path[1, :]))[0]
    ~~~~~~~^^^
ValueError: setting an array element with a sequence.
```

these fixes were generated by chatGPT:

- e631acc69a1a1dd94653823347ca3d7cb77b15b3
  - "`np.where(...)[0]` returns an array of indices, not a scalar."
  - "NumPy no longer auto-converts that into a scalar assignment."
- 1e31cf9d9e54bd1b299fba63d15e9360e09ea88f
  - "Right now it relies on exact equality"
  - "That is dangerous for DTW paths."
  - "later refinement stages may introduce tiny float errors"
